### PR TITLE
Render Emoji

### DIFF
--- a/src/components/ContentEditableInput.tsx
+++ b/src/components/ContentEditableInput.tsx
@@ -1,0 +1,286 @@
+import React, { useRef, useEffect, useCallback } from "react";
+import styled from "styled-components";
+import { useAppStore } from "@hooks/useAppStore";
+import useLogger from "@/hooks/useLogger";
+
+const ContentEditableDiv = styled.div`
+	resize: none;
+	border: none;
+	outline: none;
+	background-color: transparent;
+	color: var(--text);
+	overflow-wrap: break-word;
+	word-break: break-word;
+	white-space: break-spaces;
+	font-size: 16px;
+	font-family: var(--font-family);
+	flex: 1;
+	padding: 13px 10px;
+	min-height: 20px;
+	max-height: 50vh;
+	overflow-y: auto;
+
+	&:empty:before {
+		content: attr(data-placeholder);
+		color: var(--text-muted);
+		pointer-events: none;
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+		color: var(--text-disabled);
+	}
+
+	img.emoji {
+		width: 22px;
+		height: 22px;
+		vertical-align: middle;
+		margin: 0 1px;
+	}
+`;
+
+interface Props {
+	id: string;
+	value: string;
+	onChange: (value: string) => void;
+	onKeyDown?: (e: React.KeyboardEvent) => void;
+	placeholder?: string;
+	disabled?: boolean;
+	maxLength?: number;
+}
+
+export function ContentEditableInput({
+	id,
+	value,
+	onChange,
+	onKeyDown,
+	placeholder = "",
+	disabled = false,
+	maxLength,
+}: Props) {
+	const divRef = useRef<HTMLDivElement>(null);
+	const logger = useLogger("ContentEditableInput");
+	const app = useAppStore();
+	const lastValueRef = useRef(value);
+
+	// Convert plain text with emoji syntax to rich HTML
+	const convertTextToHtml = useCallback(
+		(text: string): string => {
+			const emojiRegex = /:(\w+):/g;
+			let html = text;
+
+			html = html.replace(emojiRegex, (match, emojiName) => {
+				// First check custom emojis
+				const customEmoji = Array.from(app.emojis.all.values()).find((emoji) => emoji.name === emojiName);
+
+				if (customEmoji) {
+					return `<img class="emoji" src="${customEmoji.imageUrl}" alt="${emojiName}" title="${emojiName}" data-emoji-name="${emojiName}" data-emoji-id="${customEmoji.id}" />`;
+				}
+
+				// If no custom emoji found, leave as text
+				return match;
+			});
+
+			// Escape other HTML and preserve line breaks
+			html = html.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\n/g, "<br>");
+
+			return html;
+		},
+		[app.emojis],
+	);
+
+	// Convert rich HTML back to plain text with emoji syntax
+	const convertHtmlToText = useCallback((html: string): string => {
+		const tempDiv = document.createElement("div");
+		tempDiv.innerHTML = html;
+
+		// Replace emoji images with text syntax
+		const emojiImages = tempDiv.querySelectorAll("img.emoji");
+		emojiImages.forEach((img) => {
+			const emojiName = img.getAttribute("data-emoji-name");
+			if (emojiName) {
+				const textNode = document.createTextNode(`:${emojiName}:`);
+				img.parentNode?.replaceChild(textNode, img);
+			}
+		});
+
+		// Convert <br> back to newlines and get text content
+		tempDiv.innerHTML = tempDiv.innerHTML.replace(/<br>/g, "\n");
+		return tempDiv.textContent || "";
+	}, []);
+
+	// Update the div content when value prop changes
+	useEffect(() => {
+		if (!divRef.current) return;
+
+		const currentText = convertHtmlToText(divRef.current.innerHTML);
+		if (currentText !== value) {
+			const html = convertTextToHtml(value);
+			divRef.current.innerHTML = html;
+			lastValueRef.current = value;
+		}
+	}, [value, convertTextToHtml, convertHtmlToText]);
+
+	const handleInput = useCallback(() => {
+		if (!divRef.current) return;
+
+		const selection = window.getSelection();
+		let savedRange = null;
+		let cursorOffset = 0;
+
+		// Save current cursor position before any changes
+		if (selection && selection.rangeCount > 0) {
+			savedRange = selection.getRangeAt(0).cloneRange();
+			// Calculate how far we are from the start
+			const tempRange = document.createRange();
+			tempRange.selectNodeContents(divRef.current);
+			tempRange.setEnd(savedRange.startContainer, savedRange.startOffset);
+			cursorOffset = tempRange.toString().length;
+		}
+
+		const currentHtml = divRef.current.innerHTML;
+		const plainText = convertHtmlToText(currentHtml);
+
+		// Check if we need to process emoji replacements
+		const emojiRegex = /:(\w+):/g;
+		let hasChanges = false;
+		let newHtml = currentHtml;
+		let offsetAdjustment = 0; // Track how much we've changed the content length
+
+		// Find recently typed emoji patterns and replace them
+		const matches = Array.from(plainText.matchAll(emojiRegex));
+
+		for (const match of matches) {
+			const emojiName = match[1];
+			const customEmoji = Array.from(app.emojis.all.values()).find((emoji) => emoji.name === emojiName);
+
+			if (customEmoji) {
+				const existingImages = divRef.current.querySelectorAll(`img[data-emoji-name="${emojiName}"]`);
+				const textMatches = (plainText.match(new RegExp(`:${emojiName}:`, "g")) || []).length;
+
+				if (textMatches > existingImages.length) {
+					const emojiHtml = `<img class="emoji" src="${customEmoji.imageUrl}" alt="${emojiName}" title="${emojiName}" data-emoji-name="${emojiName}" data-emoji-id="${customEmoji.id}" />`;
+					const originalText = `:${emojiName}:`;
+
+					if (match.index !== undefined && match.index === cursorOffset - originalText.length) {
+						// Special case: we just typed this emoji (cursor is right after it)
+						// Don't adjust offset, just position cursor after the new image
+						newHtml = newHtml.replace(originalText, emojiHtml);
+						hasChanges = true;
+
+						// Set a flag to position cursor after this specific emoji
+						setTimeout(() => {
+							const newImages = divRef.current?.querySelectorAll(`img[data-emoji-name="${emojiName}"]`);
+							if (newImages && newImages.length > 0) {
+								const lastImage = newImages[newImages.length - 1];
+								const range = document.createRange();
+								range.setStartAfter(lastImage);
+								range.collapse(true);
+								const sel = window.getSelection();
+								sel?.removeAllRanges();
+								sel?.addRange(range);
+							}
+						}, 0);
+						continue;
+					} else if (match.index !== undefined && match.index < cursorOffset) {
+						// This replacement affects our cursor position
+						const lengthDifference = emojiHtml.length - originalText.length;
+						offsetAdjustment += lengthDifference;
+					}
+
+					newHtml = newHtml.replace(originalText, emojiHtml);
+					hasChanges = true;
+				}
+			}
+		}
+
+		if (hasChanges) {
+			divRef.current.innerHTML = newHtml;
+
+			// Only do complex cursor positioning if we're not handling a just-typed emoji
+			if (offsetAdjustment !== 0) {
+				// Restore cursor position with adjustment
+				try {
+					const adjustedOffset = cursorOffset + offsetAdjustment;
+
+					const newPlainText = convertHtmlToText(divRef.current.innerHTML);
+					const targetPosition = Math.min(adjustedOffset, newPlainText.length);
+
+					// Walk through the DOM to find the position
+					let currentPos = 0;
+					let targetNode = null;
+					let targetOffset = 0;
+
+					const walker = document.createTreeWalker(divRef.current, NodeFilter.SHOW_TEXT, null);
+
+					let node;
+					while ((node = walker.nextNode())) {
+						const nodeLength = node.textContent?.length || 0;
+						if (currentPos + nodeLength >= targetPosition) {
+							targetNode = node;
+							targetOffset = targetPosition - currentPos;
+							break;
+						}
+						currentPos += nodeLength;
+					}
+
+					if (targetNode) {
+						const newRange = document.createRange();
+						newRange.setStart(targetNode, targetOffset);
+						newRange.collapse(true);
+						selection?.removeAllRanges();
+						selection?.addRange(newRange);
+					} else {
+						// Fallback: position at end
+						const newRange = document.createRange();
+						newRange.selectNodeContents(divRef.current);
+						newRange.collapse(false);
+						selection?.removeAllRanges();
+						selection?.addRange(newRange);
+					}
+				} catch (e) {
+					divRef.current.focus();
+				}
+			}
+		}
+
+		const finalText = convertHtmlToText(divRef.current.innerHTML);
+
+		if (finalText !== lastValueRef.current) {
+			lastValueRef.current = finalText;
+			onChange(finalText);
+		}
+	}, [convertHtmlToText, app.emojis, onChange]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLDivElement>) => {
+			if (maxLength && divRef.current) {
+				const currentText = convertHtmlToText(divRef.current.innerHTML);
+				if (
+					currentText.length >= maxLength &&
+					!["Backspace", "Delete", "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)
+				) {
+					e.preventDefault();
+					return;
+				}
+			}
+
+			onKeyDown?.(e);
+		},
+		[maxLength, convertHtmlToText, onKeyDown],
+	);
+
+	return (
+		<ContentEditableDiv
+			id={id}
+			ref={divRef}
+			contentEditable={!disabled}
+			onInput={handleInput}
+			onKeyDown={handleKeyDown}
+			data-placeholder={placeholder}
+			suppressContentEditableWarning={true}
+		/>
+	);
+}
+
+export default ContentEditableInput;

--- a/src/components/ContentEditableInput.tsx
+++ b/src/components/ContentEditableInput.tsx
@@ -63,7 +63,6 @@ export function ContentEditableInput({
 	const app = useAppStore();
 	const lastValueRef = useRef(value);
 
-	// Convert plain text with emoji syntax to rich HTML
 	const convertTextToHtml = useCallback(
 		(text: string): string => {
 			const emojiRegex = /:(\w+):/g;
@@ -77,7 +76,6 @@ export function ContentEditableInput({
 					return `<img class="emoji" src="${customEmoji.imageUrl}" alt="${emojiName}" title="${emojiName}" data-emoji-name="${emojiName}" data-emoji-id="${customEmoji.id}" />`;
 				}
 
-				// If no custom emoji found, leave as text
 				return match;
 			});
 
@@ -89,7 +87,6 @@ export function ContentEditableInput({
 		[app.emojis],
 	);
 
-	// Convert rich HTML back to plain text with emoji syntax
 	const convertHtmlToText = useCallback((html: string): string => {
 		const tempDiv = document.createElement("div");
 		tempDiv.innerHTML = html;
@@ -109,7 +106,6 @@ export function ContentEditableInput({
 		return tempDiv.textContent || "";
 	}, []);
 
-	// Update the div content when value prop changes
 	useEffect(() => {
 		if (!divRef.current) return;
 

--- a/src/components/EmojiRenderer.tsx
+++ b/src/components/EmojiRenderer.tsx
@@ -1,0 +1,37 @@
+import { useAppStore } from "@hooks/useAppStore";
+import { ParsedEmoji } from "@/utils/emojiParser";
+
+interface Props {
+	emoji: ParsedEmoji;
+	size?: number;
+}
+
+function EmojiRenderer({ emoji, size = 22 }: Props) {
+	const app = useAppStore();
+
+	if (emoji.type === "custom" && emoji.id) {
+		// Find the custom emoji by ID
+		const customEmoji = app.emojis.get(emoji.id);
+		if (customEmoji) {
+			return (
+				<img
+					src={customEmoji.imageUrl}
+					alt={`:${emoji.name}:`}
+					title={`:${emoji.name}:`}
+					style={{
+						width: size,
+						height: size,
+						display: "inline-block",
+						verticalAlign: "middle",
+						objectFit: "contain",
+					}}
+				/>
+			);
+		}
+	}
+
+	// Fallback to text
+	return <span>:{emoji.name}:</span>;
+}
+
+export default EmojiRenderer;

--- a/src/components/EmojiRenderer.tsx
+++ b/src/components/EmojiRenderer.tsx
@@ -10,14 +10,13 @@ function EmojiRenderer({ emoji, size = 22 }: Props) {
 	const app = useAppStore();
 
 	if (emoji.type === "custom" && emoji.id) {
-		// Find the custom emoji by ID
 		const customEmoji = app.emojis.get(emoji.id);
 		if (customEmoji) {
 			return (
 				<img
 					src={customEmoji.imageUrl}
-					alt={`:${emoji.name}:`}
-					title={`:${emoji.name}:`}
+					alt={emoji.name}
+					title={emoji.name}
 					style={{
 						width: size,
 						height: size,
@@ -30,7 +29,6 @@ function EmojiRenderer({ emoji, size = 22 }: Props) {
 		}
 	}
 
-	// Fallback to text
 	return <span>:{emoji.name}:</span>;
 }
 

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -8,7 +8,7 @@ import { MAX_ATTACHMENTS, Snowflake } from "@utils";
 import debounce from "@utils/debounce";
 import { EmojiClickData } from "emoji-picker-react";
 import { observer } from "mobx-react-lite";
-import React, { useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import styled from "styled-components";
 import Icon from "../Icon";
 import IconButton from "../IconButton";
@@ -62,11 +62,17 @@ function MessageInput({ channel }: Props) {
 	const [attachments, setAttachments] = useState<File[]>([]);
 	const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
 	const emoteButtonRef = useRef<HTMLButtonElement>(null);
+	const [savedSelection, setSavedSelection] = useState<{
+		startContainer: Node;
+		startOffset: number;
+		endContainer: Node;
+		endOffset: number;
+	} | null>(null);
 
 	/**
 	 * Debounced stopTyping
 	 */
-	const debouncedStopTyping = React.useCallback(
+	const debouncedStopTyping = useCallback(
 		debounce(() => channel.stopTyping(), 10_000),
 		[channel],
 	);
@@ -74,7 +80,7 @@ function MessageInput({ channel }: Props) {
 	/**
 	 * @returns Whether or not a message can be sent given the current state
 	 */
-	const canSendMessage = React.useCallback(() => {
+	const canSendMessage = useCallback(() => {
 		if (!attachments.length && (!content || !content.trim() || !content.replace(/\r?\n|\r/g, ""))) {
 			return false;
 		}
@@ -82,14 +88,33 @@ function MessageInput({ channel }: Props) {
 		return true;
 	}, [attachments, content]);
 
-	const sendMessage = React.useCallback(async () => {
+	const convertCustomEmojisForSending = useCallback(
+		(text: string): string => {
+			const emojiRegex = /:(\w+):/g;
+
+			return text.replace(emojiRegex, (match, emojiName) => {
+				const customEmoji = Array.from(app.emojis.all.values()).find((emoji) => emoji.name === emojiName);
+
+				if (customEmoji) {
+					return `<:${emojiName}:${customEmoji.id}>`;
+				}
+
+				// TODO: Replace with Twemoji for consistency
+				return match;
+			});
+		},
+		[app.emojis],
+	);
+
+	const sendMessage = useCallback(async () => {
 		channel.stopTyping();
 		const shouldFail = app.experiments.isTreatmentEnabled("message_queue", 2);
 		const shouldSend = !app.experiments.isTreatmentEnabled("message_queue", 1);
 
 		if (!canSendMessage() && !shouldFail) return;
 
-		const contentCopy = content;
+		const contentForSending = convertCustomEmojisForSending(content);
+		const contentCopy = contentForSending;
 		const attachmentsCopy = attachments;
 
 		setContent("");
@@ -114,13 +139,13 @@ function MessageInput({ channel }: Props) {
 				let body: RESTPostAPIChannelMessageJSONBody | FormData;
 				if (attachmentsCopy.length > 0) {
 					const data = new FormData();
-					data.append("payload_json", JSON.stringify({ content, nonce }));
+					data.append("payload_json", JSON.stringify({ contentForSending, nonce }));
 					attachmentsCopy.forEach((file, index) => {
 						data.append(`files[${index}]`, file);
 					});
 					body = data;
 				} else {
-					body = { content, nonce };
+					body = { content: contentForSending, nonce };
 				}
 				await channel.sendMessage(body, msg);
 			} catch (e) {
@@ -132,17 +157,17 @@ function MessageInput({ channel }: Props) {
 		}
 	}, [content, attachments, channel, canSendMessage]);
 
-	const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+	const onKeyDown = (e: React.KeyboardEvent) => {
 		if (e.ctrlKey && e.key === "Enter") {
 			e.preventDefault();
-			return sendMessage();
+			sendMessage();
 		}
 
 		// TODO: handle editing last message
 
 		if (!e.shiftKey && e.key === "Enter") {
 			e.preventDefault();
-			return sendMessage();
+			sendMessage();
 		}
 
 		if (e.key === "Escape") {
@@ -154,8 +179,8 @@ function MessageInput({ channel }: Props) {
 		debouncedStopTyping(true);
 	};
 
-	const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-		setContent(e.target.value);
+	const onChange = (value: string) => {
+		setContent(value);
 		channel.startTyping();
 	};
 
@@ -173,24 +198,154 @@ function MessageInput({ channel }: Props) {
 	};
 
 	const onEmojiButtonClick = () => {
+		const textArea = document.querySelector('[contenteditable="true"]') as HTMLDivElement;
+		if (textArea) {
+			textArea.focus();
+			const selection = window.getSelection();
+			if (selection && selection.rangeCount > 0) {
+				const range = selection.getRangeAt(0);
+				setSavedSelection({
+					startContainer: range.startContainer,
+					startOffset: range.startOffset,
+					endContainer: range.endContainer,
+					endOffset: range.endOffset,
+				});
+			}
+		}
+
 		setIsEmojiPickerOpen((prev) => !prev);
 	};
 
 	const onEmojiSelect = (e: EmojiClickData) => {
 		if (!e) return;
-		let emojiToInsert: string;
+
+		const textArea = document.querySelector('[contenteditable="true"]') as HTMLDivElement;
+		if (!textArea) return;
 
 		if (e.isCustom && e.imageUrl) {
-			// TODO: Handle animated case <a:name:id>
-			emojiToInsert = `<:${e.names[0]}:${e.emoji}>`;
+			// For custom emojis, find the emoji data and insert HTML directly
+			const customEmoji = Array.from(app.emojis.all.values()).find((emoji) => emoji.name === e.names[0]);
+
+			if (customEmoji) {
+				const emojiImg = document.createElement("img");
+				emojiImg.className = "emoji";
+				emojiImg.src = customEmoji.imageUrl;
+				emojiImg.alt = customEmoji.name;
+				emojiImg.title = customEmoji.name;
+				emojiImg.setAttribute("data-emoji-name", customEmoji.name);
+				emojiImg.setAttribute("data-emoji-id", customEmoji.id);
+
+				insertElementAtCursor(textArea, emojiImg);
+			}
 		} else {
-			emojiToInsert = e.emoji;
+			// For unicode emojis, insert as text
+			// TODO: Map to Twemoji for consistency
+			insertTextAtCursor(textArea, e.emoji);
 		}
 
-		setContent((prev) => prev + emojiToInsert);
-		document.getElementById("messageinput")?.focus();
+		const newContent = convertHtmlToText(textArea.innerHTML);
+		setContent(newContent);
+
 		setIsEmojiPickerOpen(false);
 		channel.startTyping();
+	};
+
+	const insertElementAtCursor = (element: HTMLDivElement, nodeToInsert: Node) => {
+		element.focus();
+
+		const selection = window.getSelection();
+
+		// Try to restore saved cursor position first
+		if (savedSelection && selection) {
+			try {
+				const range = document.createRange();
+				range.setStart(savedSelection.startContainer, savedSelection.startOffset);
+				range.setEnd(savedSelection.endContainer, savedSelection.endOffset);
+				selection.removeAllRanges();
+				selection.addRange(range);
+			} catch (e) {
+				// Fallback
+				logger.warn("Failed to restore saved selection:", e);
+
+				const range = document.createRange();
+				range.selectNodeContents(element);
+				range.collapse(false);
+				selection.removeAllRanges();
+				selection.addRange(range);
+			}
+		}
+
+		if (selection && selection.rangeCount > 0) {
+			const range = selection.getRangeAt(0);
+			range.deleteContents();
+			range.insertNode(nodeToInsert);
+
+			// Position cursor after the inserted element
+			range.setStartAfter(nodeToInsert);
+			range.collapse(true);
+			selection.removeAllRanges();
+			selection.addRange(range);
+
+			setSavedSelection(null);
+			return true;
+		}
+
+		return false;
+	};
+
+	const insertTextAtCursor = (element: HTMLDivElement, text: string) => {
+		element.focus();
+
+		const selection = window.getSelection();
+
+		if (savedSelection && selection) {
+			try {
+				const range = document.createRange();
+				range.setStart(savedSelection.startContainer, savedSelection.startOffset);
+				range.setEnd(savedSelection.endContainer, savedSelection.endOffset);
+				selection.removeAllRanges();
+				selection.addRange(range);
+			} catch (e) {
+				logger.warn("Failed to restore saved selection:", e);
+				const range = document.createRange();
+				range.selectNodeContents(element);
+				range.collapse(false);
+				selection.removeAllRanges();
+				selection.addRange(range);
+			}
+		}
+
+		if (selection && selection.rangeCount > 0) {
+			const range = selection.getRangeAt(0);
+			range.deleteContents();
+			const textNode = document.createTextNode(text);
+			range.insertNode(textNode);
+			range.collapse(false);
+			selection.removeAllRanges();
+			selection.addRange(range);
+
+			setSavedSelection(null);
+			return true;
+		}
+
+		return false;
+	};
+
+	const convertHtmlToText = (html: string): string => {
+		const tempDiv = document.createElement("div");
+		tempDiv.innerHTML = html;
+
+		const emojiImages = tempDiv.querySelectorAll("img.emoji");
+		emojiImages.forEach((img) => {
+			const emojiName = img.getAttribute("data-emoji-name");
+			if (emojiName) {
+				const textNode = document.createTextNode(`:${emojiName}:`);
+				img.parentNode?.replaceChild(textNode, img);
+			}
+		});
+
+		tempDiv.innerHTML = tempDiv.innerHTML.replace(/<br>/g, "\n");
+		return tempDiv.textContent || "";
 	};
 
 	return (

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -178,8 +178,16 @@ function MessageInput({ channel }: Props) {
 
 	const onEmojiSelect = (e: EmojiClickData) => {
 		if (!e) return;
-		const emoji = e.emoji;
-		setContent((prev) => prev + emoji);
+		let emojiToInsert: string;
+
+		if (e.isCustom && e.imageUrl) {
+			// TODO: Handle animated case <a:name:id>
+			emojiToInsert = `<:${e.names[0]}:${e.emoji}>`;
+		} else {
+			emojiToInsert = e.emoji;
+		}
+
+		setContent((prev) => prev + emojiToInsert);
 		document.getElementById("messageinput")?.focus();
 		setIsEmojiPickerOpen(false);
 		channel.startTyping();

--- a/src/components/messaging/MessageTextArea.tsx
+++ b/src/components/messaging/MessageTextArea.tsx
@@ -1,46 +1,34 @@
-// import { TextareaAutosize, TextareaAutosizeProps } from "@mui/material";
 import { isTouchscreenDevice } from "@utils";
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
-import { TextareaAutosize, TextareaAutosizeProps } from "./TextareaAutosize";
+import ContentEditableInput from "../ContentEditableInput";
 
 const Container = styled.div`
 	flex: 1;
 	display: flex;
 `;
 
-const TextArea = styled(TextareaAutosize)`
-	resize: none;
-	border: none;
-	outline: none;
-	background-color: transparent;
-	color: var(--text);
-	// border-radius: 10px;
-	overflow-wrap: break-word;
-	word-break: break-word;
-	white-space: break-spaces;
-	font-size: 16px;
-	font-family: var(--font-family);
-	flex: 1;
-	padding: 13px 10px;
+interface Props {
+	id: string;
+	value: string;
+	onChange: (value: string) => void;
+	onKeyDown?: (e: React.KeyboardEvent) => void;
+	placeholder?: string;
+	disabled?: boolean;
+	maxLength?: number;
+}
 
-	&:disabled {
-		cursor: not-allowed;
-		color: var(--text-disabled);
-	}
-`;
+function MessageTextArea({ id, value, onChange, onKeyDown, placeholder, disabled, maxLength }: Props) {
+	const ref = React.useRef<HTMLDivElement | null>(null);
 
-function MessageTextArea(props: TextareaAutosizeProps) {
-	const ref = React.useRef<HTMLTextAreaElement | null>(null);
-
-	React.useEffect(() => {
+	useEffect(() => {
 		if (isTouchscreenDevice) return;
 		if (ref.current) ref.current.focus();
-	}, [props.value]);
+	}, [value]);
 
-	const inputSelected = () => ["TEXTAREA", "INPUT"].includes(document.activeElement?.nodeName ?? "");
+	const inputSelected = () => ["TEXTAREA", "INPUT", "DIV"].includes(document.activeElement?.nodeName ?? "");
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if (!ref.current) return;
 
 		if (isTouchscreenDevice) return;
@@ -58,17 +46,18 @@ function MessageTextArea(props: TextareaAutosizeProps) {
 
 		document.body.addEventListener("keydown", keyDown);
 		return () => document.body.removeEventListener("keydown", keyDown);
-	}, [ref, props.value]);
+	}, [ref, value]);
 
 	return (
 		<Container>
-			<TextArea
-				ref={ref}
-				{...props}
-				maxRows={
-					// 50vh
-					Math.floor((window.innerHeight * 0.5) / 20)
-				}
+			<ContentEditableInput
+				id={id}
+				value={value}
+				onChange={onChange}
+				onKeyDown={onKeyDown}
+				placeholder={placeholder}
+				disabled={disabled}
+				maxLength={maxLength}
 			/>
 		</Container>
 	);

--- a/src/utils/emojiParser.ts
+++ b/src/utils/emojiParser.ts
@@ -1,0 +1,38 @@
+export interface ParsedEmoji {
+	type: "unicode" | "custom";
+	id: string;
+	name: string;
+	animated?: boolean;
+	unified?: string;
+}
+
+export function parseEmojiString(content: string): (string | ParsedEmoji)[] {
+	// Discord-style emoji regex: <:name:id> or <a:name:id>
+	const emojiRegex = /<(a?):(\w+):(\d+)>/g;
+	const parts: (string | ParsedEmoji)[] = [];
+	let lastIndex = 0;
+	let match;
+
+	while ((match = emojiRegex.exec(content)) !== null) {
+		// Add text before emoji
+		if (match.index > lastIndex) {
+			parts.push(content.slice(lastIndex, match.index));
+		}
+
+		parts.push({
+			type: "custom",
+			animated: match[1] === "a",
+			name: match[2],
+			id: match[3],
+		});
+
+		lastIndex = match.index + match[0].length;
+	}
+
+	// Add remaining text
+	if (lastIndex < content.length) {
+		parts.push(content.slice(lastIndex));
+	}
+
+	return parts;
+}


### PR DESCRIPTION
*This PR is not ready to merge, I'd like to clean up the code a bit and do more testing*

## What changed?

- Render custom emoji in messages
- Replace `TextArea` with `ContentEditableInput`
    - `<textarea />` doesn't support inline images, using a div with `contenteditable=true` is the recommended way to get this working.
- Add functionality for rendering emoji in `ContentEditableInput`

## How was this tested?

- By opening the emoji picker and selecting custom/non-custom emoji
- Checking that they were inserted at the proper cursor position
- Tested that pressing backspace on an emoji only requires only 1 press
- Using the :shortcode: to add emojis without the emoji picker

| After |
| :-: |
| <video src="https://github.com/user-attachments/assets/470fc4f5-7b81-4a8e-a4cf-ebf636c9ae40" /> |

## Additional notes

- I've noticed that the emoji picker jumps when it first opens. I'll be sure to address that in another PR.